### PR TITLE
Ci rejig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,6 @@ save_registry: &SAVE_REGISTRY
     key: registry-{{ .BuildNum }}
     paths:
     - /usr/local/cargo/registry/index
-deps_key: &DEPS_KEY
-  key: deps-{{ checksum "~/rust-version" }}-{{ checksum "Cargo.lock" }}
-restore_deps: &RESTORE_DEPS
-  restore_cache:
-    <<: *DEPS_KEY
-save_deps: &SAVE_DEPS
-  save_cache:
-    <<: *DEPS_KEY
-    paths:
-    - target
-    - /usr/local/cargo/registry/cache
 
 version: 2
 jobs:
@@ -33,7 +22,5 @@ jobs:
       - *RESTORE_REGISTRY
       - run: rustc --version | tee ~/rust-version
       - run: cargo fmt -- --check
-      - *RESTORE_DEPS
       - run: cargo test --all
       - *SAVE_REGISTRY
-      - *SAVE_DEPS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,9 @@ jobs:
     steps:
       - checkout
       - *RESTORE_REGISTRY
-      - run: cargo generate-lockfile
-      - *SAVE_REGISTRY
       - run: rustc --version | tee ~/rust-version
       - run: cargo fmt -- --check
       - *RESTORE_DEPS
       - run: cargo test --all
+      - *SAVE_REGISTRY
       - *SAVE_DEPS


### PR DESCRIPTION
* Don't use generate-lockfile, as it's slow
* Skip caching build dependencies, as we don't keep a lockfile, and don't want it to grow endlessly (and invalidation is a pain)